### PR TITLE
Expore port 5000 to be ElasticBeanstalk ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .project
 *.rdb
 junit*xml
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ WORKDIR /app
 RUN pip install -r requirements.txt
 WORKDIR /app/snappass
 ENTRYPOINT ["python"]
+EXPOSE 5000
 CMD ["main.py"]


### PR DESCRIPTION
Hi there,

we did instantiate a snappass machine on our domain, and since we're using Elastic Beanstalk, I saw the missing `EXPOSE`.

And since I had to thank you for publishing your work, here it is: thanks for sharing man 😃 

Hope everything's going well for you
